### PR TITLE
feat:[윤상근]카드의 ‘attack_point’ 정보를 사전에 읽어 각 Card attack_point Domain 에서…

### DIFF
--- a/src/card_activation_energy/mod.rs
+++ b/src/card_activation_energy/mod.rs
@@ -1,0 +1,2 @@
+pub mod repository;
+pub mod service;

--- a/src/card_activation_energy/repository/card_activation_energy_repository.rs
+++ b/src/card_activation_energy/repository/card_activation_energy_repository.rs
@@ -1,0 +1,15 @@
+use std::collections::HashMap;
+use async_trait::async_trait;
+use crate::common::card_attributes::card_activation_energy::activation_energy_enum::ActivationEnergyEnum;
+// use crate::common::card_attributes::card_activation_energy::activation_energy_enum::ActivationEnergyEnum::ActivationEnergy;
+
+
+#[async_trait]
+pub trait CardActivationEnergyRepository {
+    async fn get_card_activation_energy(&self, card_number: &i32) -> i32;
+
+}
+
+
+
+

--- a/src/card_activation_energy/repository/card_activation_energy_repository_impl.rs
+++ b/src/card_activation_energy/repository/card_activation_energy_repository_impl.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::card_activation_energy::repository::card_activation_energy_repository::CardActivationEnergyRepository;
+use crate::common::card_attributes::card_activation_energy::activation_energy_enum::ActivationEnergyEnum;
+use crate::common::csv::csv_reader::{build_card_activation_energy_dictionary, csv_read};
+use crate::common::path::root_path::RootPath;
+
+
+pub struct CardActivationEnergyRepositoryImpl {
+    card_activation_energy_map: Arc<AsyncMutex<HashMap<i32, i32>>>,
+}
+
+impl CardActivationEnergyRepositoryImpl {
+    pub fn new() -> Self {
+        let filename = RootPath::make_full_path("resources/csv/card_data.csv")
+            .unwrap_or_else(|| {
+                eprintln!("Failed to get file path.");
+                std::process::exit(1);
+            });
+        let filename_path = &filename.to_string_lossy();
+
+        let csv_content = match csv_read(filename_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("Error reading CSV file: {}", err);
+                std::process::exit(1);
+            }
+        };
+
+        let card_activation_energy_dictionary = build_card_activation_energy_dictionary(&csv_content);
+
+        CardActivationEnergyRepositoryImpl {
+            card_activation_energy_map: Arc::new(AsyncMutex::new(card_activation_energy_dictionary)),
+        }
+    }
+
+    pub fn get_instance() -> Arc<AsyncMutex<CardActivationEnergyRepositoryImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardActivationEnergyRepositoryImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardActivationEnergyRepositoryImpl::new()));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardActivationEnergyRepository for CardActivationEnergyRepositoryImpl {
+    async fn get_card_activation_energy(&self, card_number: &i32) -> i32 {
+        let card_card_activation_energy_map_guard = self.card_activation_energy_map.lock().await;
+        card_card_activation_energy_map_guard.get(card_number).unwrap_or(&0).clone()
+    }
+
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_card_activation_energy() {
+        let card_activation_energy_repository_mutex = CardActivationEnergyRepositoryImpl::get_instance();
+        let card_activation_energy_repository_guard = card_activation_energy_repository_mutex.lock().await;
+        let card_number: i32 = 6;
+        let card_activation_energy = card_activation_energy_repository_guard.get_card_activation_energy(&card_number).await;
+
+
+
+        println!("card_activation_energy: {:?}", card_activation_energy);
+    }
+}
+
+

--- a/src/card_activation_energy/repository/mod.rs
+++ b/src/card_activation_energy/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_activation_energy_repository;
+pub mod card_activation_energy_repository_impl;

--- a/src/card_activation_energy/service/card_activation_energy_service.rs
+++ b/src/card_activation_energy/service/card_activation_energy_service.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+
+use crate::common::card_attributes::card_activation_energy::activation_energy_enum::ActivationEnergyEnum;
+
+
+#[async_trait]
+pub trait CardActivationEnergyService {
+    async fn get_card_activation_energy(&self, card_number: &i32) -> i32;
+}

--- a/src/card_activation_energy/service/card_activation_energy_service_impl.rs
+++ b/src/card_activation_energy/service/card_activation_energy_service_impl.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+
+use tokio::sync::Mutex as AsyncMutex;
+use crate::card_activation_energy::repository::card_activation_energy_repository::CardActivationEnergyRepository;
+
+use crate::card_activation_energy::repository::card_activation_energy_repository_impl::CardActivationEnergyRepositoryImpl;
+use crate::card_activation_energy::service::card_activation_energy_service::CardActivationEnergyService;
+use crate::common::card_attributes::card_activation_energy::activation_energy_enum::ActivationEnergyEnum;
+
+pub struct CardActivationEnergyServiceImpl {
+    card_activation_energy_repository: Arc<AsyncMutex<CardActivationEnergyRepositoryImpl>>
+}
+
+impl CardActivationEnergyServiceImpl {
+    pub fn new(card_activation_energy_repository: Arc<AsyncMutex<CardActivationEnergyRepositoryImpl>>) -> Self {
+        CardActivationEnergyServiceImpl {
+            card_activation_energy_repository
+        }
+    }
+    pub fn get_instance() -> Arc<AsyncMutex<CardActivationEnergyServiceImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardActivationEnergyServiceImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardActivationEnergyServiceImpl::new(
+                            CardActivationEnergyRepositoryImpl::get_instance())));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardActivationEnergyService for CardActivationEnergyServiceImpl {
+    async fn get_card_activation_energy(&self, card_number: &i32) -> i32 {
+        println!("CardActivationEnergyServiceImpl: get_card_activation_energy()");
+
+        let card_activation_energy_repository_guard = self.card_activation_energy_repository.lock().await;
+        card_activation_energy_repository_guard.get_card_activation_energy(card_number).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::test;
+
+    #[test]
+    async fn test_get_card_activation_energy() {
+        let card_activation_energy_repo_mutex = CardActivationEnergyRepositoryImpl::get_instance();
+        let card_activation_energy_guard = card_activation_energy_repo_mutex.lock().await;
+        let card_number: i32 = 19;
+        let card_activation_energy = card_activation_energy_guard.get_card_activation_energy(&card_number).await;
+
+
+        println!("Card Activation Energy: {:?}", card_activation_energy);
+
+    }
+}

--- a/src/card_activation_energy/service/mod.rs
+++ b/src/card_activation_energy/service/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_activation_energy_service;
+pub mod card_activation_energy_service_impl;

--- a/src/card_attack_point/mod.rs
+++ b/src/card_attack_point/mod.rs
@@ -1,0 +1,2 @@
+pub mod repositoty;
+pub mod service;

--- a/src/card_attack_point/repositoty/card_attack_point_repository.rs
+++ b/src/card_attack_point/repositoty/card_attack_point_repository.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+use async_trait::async_trait;
+use crate::common::card_attributes::card_attack_point::attack_point_enum::AttackPointEnum;
+
+#[async_trait]
+pub trait CardAttackPointRepository {
+    async fn get_card_attack_point(&self, card_number: &i32) -> i32;
+}
+

--- a/src/card_attack_point/repositoty/card_attack_point_repository_impl.rs
+++ b/src/card_attack_point/repositoty/card_attack_point_repository_impl.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::card_attack_point::repositoty::card_attack_point_repository::CardAttackPointRepository;
+use crate::common::card_attributes::card_attack_point::attack_point_enum::AttackPointEnum;
+use crate::common::csv::csv_reader::{build_card_attack_point_dictionary, csv_read};
+use crate::common::path::root_path::RootPath;
+
+pub struct CardAttackPointRepositoryImpl {
+    card_attack_point_map: Arc<AsyncMutex<HashMap<i32, i32>>>,
+}
+
+impl CardAttackPointRepositoryImpl {
+    pub fn new() -> Self {
+        let filename = RootPath::make_full_path("resources/csv/card_data.csv")
+            .unwrap_or_else(|| {
+                eprintln!("Failed to get file path.");
+                std::process::exit(1);
+            });
+        let filename_path = &filename.to_string_lossy();
+
+        let csv_content = match csv_read(filename_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("Error reading CSV file: {}", err);
+                std::process::exit(1);
+            }
+        };
+
+        let card_attack_point_dictionary = build_card_attack_point_dictionary(&csv_content);
+
+        CardAttackPointRepositoryImpl {
+            card_attack_point_map: Arc::new(AsyncMutex::new(card_attack_point_dictionary)),
+        }
+    }
+
+    pub fn get_instance() -> Arc<AsyncMutex<CardAttackPointRepositoryImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardAttackPointRepositoryImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardAttackPointRepositoryImpl::new()));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardAttackPointRepository for CardAttackPointRepositoryImpl {
+    async fn get_card_attack_point(&self, card_number: &i32) -> i32 {
+        let card_attack_point_map_guard = self.card_attack_point_map.lock().await;
+        card_attack_point_map_guard.get(card_number).unwrap_or(&0).clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::test;
+
+    #[tokio::test]
+    async fn test_get_card_attack_point() {
+        let card_attack_point_repository_mutex = CardAttackPointRepositoryImpl::get_instance();
+        let card_attack_point_repository_guard = card_attack_point_repository_mutex.lock().await;
+        let card_number: i32 = 6;
+        let card_attack_point = card_attack_point_repository_guard.get_card_attack_point(&card_number).await;
+
+
+
+        println!("card_attack_point: {:?}", card_attack_point);
+    }
+}
+
+

--- a/src/card_attack_point/repositoty/mod.rs
+++ b/src/card_attack_point/repositoty/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_attack_point_repository;
+pub mod card_attack_point_repository_impl;

--- a/src/card_attack_point/service/card_attack_point_service.rs
+++ b/src/card_attack_point/service/card_attack_point_service.rs
@@ -1,0 +1,8 @@
+use async_trait::async_trait;
+
+use crate::common::card_attributes::card_attack_point::attack_point_enum::AttackPointEnum;
+
+#[async_trait]
+pub trait CardAttackPointService {
+    async fn get_card_attack_point(&self, card_number: &i32) -> i32;
+}

--- a/src/card_attack_point/service/card_attack_point_service_impl.rs
+++ b/src/card_attack_point/service/card_attack_point_service_impl.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+
+use tokio::sync::Mutex as AsyncMutex;
+use crate::card_attack_point::repositoty::card_attack_point_repository::CardAttackPointRepository;
+
+use crate::card_attack_point::repositoty::card_attack_point_repository_impl::CardAttackPointRepositoryImpl;
+use crate::card_attack_point::service::card_attack_point_service::CardAttackPointService;
+use crate::common::card_attributes::card_attack_point::attack_point_enum::AttackPointEnum;
+
+
+pub struct CardAttackPointServiceImpl {
+    card_attack_point_repository: Arc<AsyncMutex<CardAttackPointRepositoryImpl>>
+}
+
+impl CardAttackPointServiceImpl {
+    pub fn new(card_attack_point_repository: Arc<AsyncMutex<CardAttackPointRepositoryImpl>>) -> Self {
+        CardAttackPointServiceImpl {
+            card_attack_point_repository
+        }
+    }
+    pub fn get_instance() -> Arc<AsyncMutex<CardAttackPointServiceImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardAttackPointServiceImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardAttackPointServiceImpl::new(
+                            CardAttackPointRepositoryImpl::get_instance())));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardAttackPointService for CardAttackPointServiceImpl {
+    async fn get_card_attack_point(&self, card_number: &i32) -> i32 {
+        println!("CardAttackPointServiceImpl: get_card_attack_point()");
+
+        let card_attack_point_repository_guard = self.card_attack_point_repository.lock().await;
+        card_attack_point_repository_guard.get_card_attack_point(card_number).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::test;
+
+    #[test]
+    async fn test_get_card_attack_point() {
+        let card_attack_point_repo_mutex = CardAttackPointRepositoryImpl::get_instance();
+        let card_attack_point_repo_guard = card_attack_point_repo_mutex.lock().await;
+        let card_number: i32 = 6;
+
+        let card_attack_point = card_attack_point_repo_guard.get_card_attack_point(&card_number).await;
+        println!("Card Grade: {:?}", card_attack_point);
+
+    }
+}

--- a/src/card_attack_point/service/mod.rs
+++ b/src/card_attack_point/service/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_attack_point_service;
+pub mod card_attack_point_service_impl;

--- a/src/card_health_point/mod.rs
+++ b/src/card_health_point/mod.rs
@@ -1,0 +1,2 @@
+pub mod repository;
+pub mod service;

--- a/src/card_health_point/repository/card_health_point_repository.rs
+++ b/src/card_health_point/repository/card_health_point_repository.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+use async_trait::async_trait;
+use  crate::common::card_attributes::card_health_point::health_point_enum::HealthPointEnum;
+
+
+#[async_trait]
+pub trait CardHealthPointRepository {
+    async fn get_card_health_point(&self, card_number: &i32) -> i32;
+}
+
+

--- a/src/card_health_point/repository/card_health_point_repository_impl.rs
+++ b/src/card_health_point/repository/card_health_point_repository_impl.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::card_health_point::repository::card_health_point_repository::CardHealthPointRepository;
+use crate::common::card_attributes::card_health_point::health_point_enum::HealthPointEnum;
+use crate::common::csv::csv_reader::{build_card_health_point_dictionary, csv_read};
+use crate::common::path::root_path::RootPath;
+
+pub struct CardHealthPointRepositoryImpl {
+    card_health_point_map: Arc<AsyncMutex<HashMap<i32, i32>>>,
+}
+
+impl CardHealthPointRepositoryImpl {
+    pub fn new() -> Self {
+        let filename = RootPath::make_full_path("resources/csv/card_data.csv")
+            .unwrap_or_else(|| {
+                eprintln!("Failed to get file path.");
+                std::process::exit(1);
+            });
+        let filename_path = &filename.to_string_lossy();
+
+        let csv_content = match csv_read(filename_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("Error reading CSV file: {}", err);
+                std::process::exit(1);
+            }
+        };
+
+        let card_health_point_dictionary = build_card_health_point_dictionary(&csv_content);
+
+        CardHealthPointRepositoryImpl {
+            card_health_point_map: Arc::new(AsyncMutex::new(card_health_point_dictionary)),
+        }
+    }
+
+    pub fn get_instance() -> Arc<AsyncMutex<CardHealthPointRepositoryImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardHealthPointRepositoryImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardHealthPointRepositoryImpl::new()));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardHealthPointRepository for CardHealthPointRepositoryImpl {
+
+    async fn get_card_health_point(&self, card_number: &i32) -> i32 {
+        let card_health_point_map_guard = self.card_health_point_map.lock().await;
+        card_health_point_map_guard.get(card_number).unwrap_or(&0).clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_card_Health_point() {
+        let card_health_point_repository_mutex = CardHealthPointRepositoryImpl::get_instance();
+        let card_health_point_repository_guard = card_health_point_repository_mutex.lock().await;
+        let card_number: i32 = 6;
+        let card_health_point = card_health_point_repository_guard.get_card_health_point(&card_number).await;
+
+
+        
+        println!("card_health_point: {:?}", card_health_point);
+    }
+}
+
+

--- a/src/card_health_point/repository/mod.rs
+++ b/src/card_health_point/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_health_point_repository;
+pub mod card_health_point_repository_impl;

--- a/src/card_health_point/service/card_health_point_service.rs
+++ b/src/card_health_point/service/card_health_point_service.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+
+use crate::common::card_attributes::card_health_point::health_point_enum::HealthPointEnum;
+
+
+#[async_trait]
+pub trait CardHealthPointService {
+    async fn get_card_health_point(&self, card_number: &i32) -> i32;
+}

--- a/src/card_health_point/service/card_health_point_service_impl.rs
+++ b/src/card_health_point/service/card_health_point_service_impl.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+
+use tokio::sync::Mutex as AsyncMutex;
+use crate::card_health_point::repository::card_health_point_repository::CardHealthPointRepository;
+
+use crate::card_health_point::repository::card_health_point_repository_impl::CardHealthPointRepositoryImpl;
+use crate::card_health_point::service::card_health_point_service::CardHealthPointService;
+use crate::common::card_attributes::card_health_point::health_point_enum::HealthPointEnum;
+
+
+
+pub struct CardHealthPointServiceImpl {
+    card_health_point_repository: Arc<AsyncMutex<CardHealthPointRepositoryImpl>>
+}
+
+impl CardHealthPointServiceImpl {
+    pub fn new(card_health_point_repository: Arc<AsyncMutex<CardHealthPointRepositoryImpl>>) -> Self {
+        CardHealthPointServiceImpl {
+            card_health_point_repository
+        }
+    }
+    pub fn get_instance() -> Arc<AsyncMutex<CardHealthPointServiceImpl>> {
+        lazy_static! {
+            static ref INSTANCE: Arc<AsyncMutex<CardHealthPointServiceImpl>> =
+                Arc::new(
+                    AsyncMutex::new(
+                        CardHealthPointServiceImpl::new(
+                            CardHealthPointRepositoryImpl::get_instance())));
+        }
+        INSTANCE.clone()
+    }
+}
+
+#[async_trait]
+impl CardHealthPointService for CardHealthPointServiceImpl {
+    async fn get_card_health_point(&self, card_number: &i32) -> i32 {
+        println!("CardHealthPointServiceImpl: get_card_health_point()");
+
+        let card_health_point_repository_guard = self.card_health_point_repository.lock().await;
+        card_health_point_repository_guard.get_card_health_point(card_number).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::test;
+
+    #[test]
+    async fn test_get_card_health_point() {
+        let card_health_point_repo_mutex = CardHealthPointRepositoryImpl::get_instance();
+        let card_health_point_repo_guard = card_health_point_repo_mutex.lock().await;
+        let card_number: i32 = 6;
+
+        let card_health_point = card_health_point_repo_guard.get_card_health_point(&card_number).await;
+        println!("Card Health Point: {:?}", card_health_point);
+
+    }
+}

--- a/src/card_health_point/service/mod.rs
+++ b/src/card_health_point/service/mod.rs
@@ -1,0 +1,2 @@
+pub mod card_health_point_service;
+pub mod card_health_point_service_impl;

--- a/src/common/card_attributes/card_activation_energy/activation_energy_enum.rs
+++ b/src/common/card_attributes/card_activation_energy/activation_energy_enum.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum ActivationEnergyEnum {
+    Dummy = 0,
+    ActivationEnergy = 1,
+}

--- a/src/common/card_attributes/card_activation_energy/mod.rs
+++ b/src/common/card_attributes/card_activation_energy/mod.rs
@@ -1,0 +1,1 @@
+pub mod activation_energy_enum;

--- a/src/common/card_attributes/card_attack_point/attack_point_enum.rs
+++ b/src/common/card_attributes/card_attack_point/attack_point_enum.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum AttackPointEnum {
+    Dummy = 0,
+    AttackPoint = 1,
+}

--- a/src/common/card_attributes/card_attack_point/mod.rs
+++ b/src/common/card_attributes/card_attack_point/mod.rs
@@ -1,0 +1,1 @@
+pub mod attack_point_enum;

--- a/src/common/card_attributes/card_health_point/health_point_enum.rs
+++ b/src/common/card_attributes/card_health_point/health_point_enum.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum HealthPointEnum {
+    Dummy = 0,
+    HealthPoint = 1,
+}

--- a/src/common/card_attributes/card_health_point/mod.rs
+++ b/src/common/card_attributes/card_health_point/mod.rs
@@ -1,0 +1,1 @@
+pub mod health_point_enum;

--- a/src/common/card_attributes/mod.rs
+++ b/src/common/card_attributes/mod.rs
@@ -1,3 +1,6 @@
 pub mod card_race;
 pub mod card_grade;
 pub mod card_kinds;
+pub mod card_activation_energy;
+pub mod card_attack_point;
+pub mod card_health_point;

--- a/src/common/csv/csv_reader.rs
+++ b/src/common/csv/csv_reader.rs
@@ -191,6 +191,45 @@ pub fn build_card_race_dictionary(csv_content: &Vec<Vec<String>>) -> HashMap<i32
     card_race_dictionary
 }
 
+pub fn build_card_activation_energy_dictionary(csv_content: &Vec<Vec<String>>) -> HashMap<i32, i32> {
+    let mut card_activation_energy_dictionary = HashMap::new();
+
+    for record in csv_content.iter() {
+        let card_number = record[0].parse::<i32>().unwrap();
+        let card_activation_energy = record[6].parse::<i32>().unwrap();
+        // card_activation_energy 어떤 record를 부여하는지 아니 상근아 csv기준 0~해서 7번같아요
+            card_activation_energy_dictionary.insert(card_number, card_activation_energy);
+
+    }
+
+    card_activation_energy_dictionary
+}
+
+pub fn build_card_attack_point_dictionary(csv_content: &Vec<Vec<String>>) -> HashMap<i32, i32> {
+    let mut card_attack_point_dictionary= HashMap::new();
+
+    for record in csv_content.iter() {
+        let card_number = record[0].parse::<i32>().unwrap();
+        let card_attack_point = record[7].parse::<i32>().unwrap();
+            card_attack_point_dictionary.insert(card_number, card_attack_point);
+    }
+
+    card_attack_point_dictionary
+}
+
+pub fn build_card_health_point_dictionary(csv_content: &Vec<Vec<String>>) -> HashMap<i32, i32> {
+    let mut card_health_point_dictionary = HashMap::new();
+
+    for record in csv_content.iter() {
+        let card_number = record[0].parse::<i32>().unwrap();
+        let card_health_point = record[8].parse::<i32>().unwrap();
+            card_health_point_dictionary.insert(card_number, card_health_point);
+
+    }
+
+    card_health_point_dictionary
+}
+
 
 // 카드 종류(서포트, 아이템 등등)
 pub fn get_card_kinds<'a>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,9 @@ mod notify_player_action;
 mod game_protocol_validation;
 mod game_card_unit;
 mod game_card_energy;
+mod card_activation_energy;
+mod card_attack_point;
+mod card_health_point;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
… In-Memory 로 관리 할 수 있습니다 [TCG-CGS-244]

카드의 ‘activation_energy’ 정보를 사전에 읽어 각 Card health_point Domain 에서 In-Memory 로 관리 할 수 있습니다 [TCG-CGS-246] 카드의 ‘health_point’ 정보를 사전에 읽어 각 Card health_point Domain 에서 In-Memory 로 관리 할 수 있습니다 [TCG-CGS-245]