### PR TITLE
필드 유닛의 액션 시작 전에 유닛이 해당 턴에 액션을 취한 적이 있는지 감지합니다 [TCG-CGS-323]

### DIFF
--- a/src/game_field_unit/entity/game_field_unit.rs
+++ b/src/game_field_unit/entity/game_field_unit.rs
@@ -59,8 +59,17 @@ impl GameFieldUnit {
     pub fn judge_death_of_unit(&mut self, unit_card_index: usize) {
         self.game_field_unit.judge_death_of_unit(unit_card_index);
     }
+    pub fn execute_turn_action_of_unit(&mut self, unit_card_index: usize) {
+        self.game_field_unit.execute_turn_action(unit_card_index)
+    }
+    pub fn reset_turn_action_of_unit(&mut self, unit_card_index: usize) {
+        self.game_field_unit.reset_turn_action(unit_card_index)
+    }
     pub fn check_unit_alive(&mut self, unit_card_index: usize) -> bool {
         return self.game_field_unit.check_unit_alive(unit_card_index)
+    }
+    pub fn check_turn_action_of_unit(&mut self, unit_card_index: usize) -> bool {
+        return self.game_field_unit.check_turn_action(unit_card_index)
     }
 
     pub fn add_special_energy_to_indexed_unit(&mut self, unit_card_index: usize, race_enum: RaceEnumValue, quantity: i32, status_effect_list: Vec<StatusEffect>) {

--- a/src/game_field_unit/entity/game_field_unit_card.rs
+++ b/src/game_field_unit/entity/game_field_unit_card.rs
@@ -22,6 +22,7 @@ pub struct GameFieldUnitCard {
     has_third_passive_skill: bool,
     extra_status_effect_list: Vec<ExtraStatusEffect>,
     harmful_status_effect_list: Vec<HarmfulStatusEffect>,
+    turn_action: bool,
     is_alive: bool,
 }
 
@@ -37,6 +38,7 @@ impl GameFieldUnitCard {
                has_third_passive_skill: bool,
                is_alive: bool) -> GameFieldUnitCard {
 
+
         GameFieldUnitCard {
             field_unit_card,
             attached_energy_map: AttachedEnergyMap::new(),
@@ -50,7 +52,8 @@ impl GameFieldUnitCard {
             has_third_passive_skill,
             extra_status_effect_list: Vec::new(),
             harmful_status_effect_list: Vec::new(),
-            is_alive
+            is_alive,
+            turn_action: false,
         }
     }
 
@@ -77,15 +80,19 @@ impl GameFieldUnitCard {
     pub fn get_extra_status_effect_list(&self) -> &Vec<ExtraStatusEffect> {
         &self.extra_status_effect_list
     }
-
+    // get
     pub fn is_alive(&self) -> bool {
         self.is_alive
     }
-
+    pub fn get_turn_action(&self) -> bool {
+        self.turn_action
+    }
     pub fn set_is_alive(&mut self, is_alive: bool) {
         self.is_alive = is_alive;
     }
-
+    pub fn set_turn_action(&mut self, turn_action: bool) {
+        self.turn_action = turn_action;
+    }
     pub fn attach_energy(&mut self, race: RaceEnumValue, quantity: i32) {
         self.attached_energy_map.add_energy(race, quantity);
     }

--- a/src/game_field_unit/entity/game_field_unit_card_list.rs
+++ b/src/game_field_unit/entity/game_field_unit_card_list.rs
@@ -74,6 +74,7 @@ impl GameFieldUnitCardList {
             }
         }
     }
+
     pub fn check_unit_alive(&mut self, unit_card_index: usize) -> bool {
         if let Some(unit) = self.game_field_unit_card_list.get_mut(unit_card_index) {
             let is_alive = unit.is_alive();
@@ -84,6 +85,15 @@ impl GameFieldUnitCardList {
         }
 
         true
+    }
+    pub fn check_turn_action(&mut self, unit_card_index: usize) -> bool {
+        self.game_field_unit_card_list.get_mut(unit_card_index).unwrap().get_turn_action()
+    }
+    pub fn execute_turn_action(&mut self, unit_card_index: usize) {
+        self.game_field_unit_card_list.get_mut(unit_card_index).unwrap().set_turn_action(true);
+    }
+    pub fn reset_turn_action(&mut self, unit_card_index: usize) {
+        self.game_field_unit_card_list.get_mut(unit_card_index).unwrap().set_turn_action(false);
     }
 
     pub fn add_special_energy_to_indexed_unit(&mut self, unit_card_index: usize, race_enum: RaceEnumValue, quantity: i32, status_effect_list: Vec<StatusEffect>) {

--- a/src/game_field_unit/repository/game_field_unit_repository.rs
+++ b/src/game_field_unit/repository/game_field_unit_repository.rs
@@ -30,6 +30,9 @@ pub trait GameFieldUnitRepository {
     fn apply_damage_to_target_unit_index(&mut self, opponent_unique_id: i32, opponent_target_unit_index: i32, damage: i32) -> bool;
     fn apply_instant_death_to_target_unit_index(&mut self, opponent_unique_id: i32, opponent_target_unit_index: i32) -> bool;
     fn judge_death_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool;
+    fn check_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool;
+    fn reset_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool;
+    fn execute_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool;
     fn attach_special_energy_to_indexed_unit(&mut self, account_unique_id: i32, unit_card_index: i32, race_enum: RaceEnum, quantity: i32, status_effect_list: Vec<StatusEffect>) -> bool;
     fn apply_harmful_status_effect_damage_iteratively(&mut self, account_unique_id: i32) -> bool;
     fn impose_harmful_state_to_indexed_unit(

--- a/src/game_field_unit/repository/game_field_unit_repository_impl.rs
+++ b/src/game_field_unit/repository/game_field_unit_repository_impl.rs
@@ -194,6 +194,29 @@ impl GameFieldUnitRepository for GameFieldUnitRepositoryImpl {
 
         false
     }
+    fn check_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool {
+        if let Some(game_field_unit) = self.game_field_unit_map.get_mut(&account_unique_id) {
+            let unit_card_index = unit_card_index as usize;
+                 game_field_unit.check_turn_action_of_unit(unit_card_index);
+        }
+        false
+    }
+
+    fn execute_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool {
+        if let Some(game_field_unit) = self.game_field_unit_map.get_mut(&account_unique_id) {
+            let unit_card_index = unit_card_index as usize;
+                game_field_unit.execute_turn_action_of_unit(unit_card_index);
+        }
+        false
+    }
+    fn reset_turn_action_of_unit(&mut self, account_unique_id: i32, unit_card_index: i32) -> bool {
+        if let Some(game_field_unit) = self.game_field_unit_map.get_mut(&account_unique_id) {
+            let unit_card_index = unit_card_index as usize;
+                game_field_unit.reset_turn_action_of_unit(unit_card_index);
+        }
+        false
+    }
+
 
     fn attach_special_energy_to_indexed_unit(&mut self, account_unique_id: i32, unit_card_index: i32, race_enum: RaceEnum, quantity: i32, status_effect_list: Vec<StatusEffect>) -> bool {
         println!("GameFieldUnitRepositoryImpl: attach_special_energy_to_indexed_unit()");

--- a/src/game_field_unit/service/game_field_unit_service.rs
+++ b/src/game_field_unit/service/game_field_unit_service.rs
@@ -14,6 +14,7 @@ use crate::game_field_unit::service::request::attach_multiple_energy_to_unit_ind
 use crate::game_field_unit::service::request::attach_special_energy_to_unit_index_request::AttachSpecialEnergyToUnitIndexRequest;
 use crate::game_field_unit::service::request::attack_target_unit_with_extra_effect_request::AttackTargetUnitWithExtraEffectRequest;
 use crate::game_field_unit::service::request::judge_death_of_unit_request::JudgeDeathOfUnitRequest;
+use crate::game_field_unit::service::request::check_turn_action_request::CheckTurnActionRequest;
 use crate::game_field_unit::service::request::detach_multiple_energy_from_field_unit_request::DetachMultipleEnergyFromFieldUnitRequest;
 use crate::game_field_unit::service::request::find_active_skill_usage_unit_id_by_index_request::FindActiveSkillUsageUnitIdByIndexRequest;
 use crate::game_field_unit::service::request::find_target_unit_id_by_index_request::FindTargetUnitIdByIndexRequest;
@@ -33,6 +34,7 @@ use crate::game_field_unit::service::response::attach_multiple_energy_to_unit_in
 use crate::game_field_unit::service::response::attach_special_energy_to_unit_index_response::AttachSpecialEnergyToUnitIndexResponse;
 use crate::game_field_unit::service::response::attack_target_unit_with_extra_effect_response::AttackTargetUnitWithExtraEffectResponse;
 use crate::game_field_unit::service::response::judge_death_of_unit_response::JudgeDeathOfUnitResponse;
+use crate::game_field_unit::service::response::check_turn_action_response::CheckTurnActionResponse;
 use crate::game_field_unit::service::response::detach_multiple_energy_from_field_unit_response::DetachMultipleEnergyFromFieldUnitResponse;
 use crate::game_field_unit::service::response::find_active_skill_usage_unit_id_by_index_response::FindActiveSkillUsageUnitIdByIndexResponse;
 use crate::game_field_unit::service::response::find_target_unit_id_by_index_response::FindTargetUnitIdByIndexResponse;
@@ -48,6 +50,10 @@ pub trait GameFieldUnitService {
     async fn apply_damage_to_target_unit_index(&mut self, apply_damage_to_target_unit_index_response: ApplyDamageToTargetUnitIndexRequest) -> ApplyDamageToTargetUnitIndexResponse;
     async fn apply_instant_death_to_target_unit_index(&mut self, apply_instant_death_to_target_unit_index_request: ApplyInstantDeathToTargetUnitIndexRequest) -> ApplyInstantDeathToTargetUnitIndexResponse;
     async fn judge_death_of_unit(&mut self, check_is_unit_alive_request: JudgeDeathOfUnitRequest) -> JudgeDeathOfUnitResponse;
+    // async fn check_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse;
+    async fn check_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse;
+    async fn execute_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse;
+    async fn reset_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse;
     async fn get_current_health_point_of_field_unit_by_index(&self, get_current_health_point_of_field_unit_by_index_request: GetCurrentHealthPointOfFieldUnitByIndexRequest) -> GetCurrentHealthPointOfFieldUnitByIndexResponse;
 
     async fn attach_special_energy_to_field_unit_index(&mut self, attach_special_energy_to_unit_index_request: AttachSpecialEnergyToUnitIndexRequest) -> AttachSpecialEnergyToUnitIndexResponse;

--- a/src/game_field_unit/service/game_field_unit_service_impl.rs
+++ b/src/game_field_unit/service/game_field_unit_service_impl.rs
@@ -24,6 +24,7 @@ use crate::game_field_unit::service::request::attach_multiple_energy_to_unit_ind
 use crate::game_field_unit::service::request::attach_special_energy_to_unit_index_request::AttachSpecialEnergyToUnitIndexRequest;
 use crate::game_field_unit::service::request::attack_target_unit_with_extra_effect_request::AttackTargetUnitWithExtraEffectRequest;
 use crate::game_field_unit::service::request::judge_death_of_unit_request::JudgeDeathOfUnitRequest;
+use crate::game_field_unit::service::request::check_turn_action_request::CheckTurnActionRequest;
 use crate::game_field_unit::service::request::detach_multiple_energy_from_field_unit_request::DetachMultipleEnergyFromFieldUnitRequest;
 use crate::game_field_unit::service::request::find_active_skill_usage_unit_id_by_index_request::FindActiveSkillUsageUnitIdByIndexRequest;
 use crate::game_field_unit::service::request::find_target_unit_id_by_index_request::FindTargetUnitIdByIndexRequest;
@@ -43,6 +44,7 @@ use crate::game_field_unit::service::response::attach_multiple_energy_to_unit_in
 use crate::game_field_unit::service::response::attach_special_energy_to_unit_index_response::AttachSpecialEnergyToUnitIndexResponse;
 use crate::game_field_unit::service::response::attack_target_unit_with_extra_effect_response::AttackTargetUnitWithExtraEffectResponse;
 use crate::game_field_unit::service::response::judge_death_of_unit_response::JudgeDeathOfUnitResponse;
+use crate::game_field_unit::service::response::check_turn_action_response::CheckTurnActionResponse;
 use crate::game_field_unit::service::response::detach_multiple_energy_from_field_unit_response::DetachMultipleEnergyFromFieldUnitResponse;
 use crate::game_field_unit::service::response::find_active_skill_usage_unit_id_by_index_response::FindActiveSkillUsageUnitIdByIndexResponse;
 use crate::game_field_unit::service::response::find_target_unit_id_by_index_response::FindTargetUnitIdByIndexResponse;
@@ -166,6 +168,44 @@ impl GameFieldUnitService for GameFieldUnitServiceImpl {
 
         JudgeDeathOfUnitResponse::new(response)
     }
+    // async fn check_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse {
+    //     println!("GameFieldUnitServiceImpl: check_turn_action()");
+    //
+    //     let mut game_field_unit_repository_guard = self.game_field_unit_repository.lock().await;
+    //     let response = game_field_unit_repository_guard.check_turn_action_of_unit(
+    //         check_turn_action_request.get_account_unique_id(),
+    //         check_turn_action_request.get_unit_card_index());
+    //
+    //     CheckTurnActionResponse::new(response)
+    // }
+    async fn check_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse {
+        println!("GameFieldUnitServiceImpl: check_turn_action()");
+
+        let mut game_field_unit_repository_guard = self.game_field_unit_repository.lock().await;
+        let response = game_field_unit_repository_guard.check_turn_action_of_unit(
+            check_turn_action_request.get_account_unique_id(),
+            check_turn_action_request.get_unit_card_index());
+        CheckTurnActionResponse::new(response)
+    }
+    async fn execute_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse {
+        println!("GameFieldUnitServiceImpl: execute_turn_action_of_unit()");
+
+        let mut game_field_unit_repository_guard = self.game_field_unit_repository.lock().await;
+        let response = game_field_unit_repository_guard.check_turn_action_of_unit(
+            check_turn_action_request.get_account_unique_id(),
+            check_turn_action_request.get_unit_card_index());
+        CheckTurnActionResponse::new(response)
+    }
+    async fn reset_turn_action(&mut self, check_turn_action_request: CheckTurnActionRequest) -> CheckTurnActionResponse {
+        println!("GameFieldUnitServiceImpl: reset_turn_action_of_unit()");
+
+        let mut game_field_unit_repository_guard = self.game_field_unit_repository.lock().await;
+        let response = game_field_unit_repository_guard.check_turn_action_of_unit(
+            check_turn_action_request.get_account_unique_id(),
+            check_turn_action_request.get_unit_card_index());
+        CheckTurnActionResponse::new(response)
+    }
+
 
     async fn get_current_health_point_of_field_unit_by_index(&self, get_current_health_point_of_field_unit_by_index_request: GetCurrentHealthPointOfFieldUnitByIndexRequest) -> GetCurrentHealthPointOfFieldUnitByIndexResponse {
         println!("GameFieldUnitServiceImpl: get_current_health_point_of_field_unit_by_index()");

--- a/src/game_field_unit/service/request/check_turn_action_request.rs
+++ b/src/game_field_unit/service/request/check_turn_action_request.rs
@@ -1,0 +1,22 @@
+#[derive(Debug)]
+pub struct CheckTurnActionRequest {
+    account_unique_id: i32,
+    unit_card_index: i32,
+}
+
+impl CheckTurnActionRequest {
+    pub fn new(account_unique_id: i32, unit_card_index: i32) -> Self {
+        CheckTurnActionRequest {
+            account_unique_id,
+            unit_card_index,
+        }
+    }
+
+    pub fn get_account_unique_id(&self) -> i32 {
+        self.account_unique_id
+    }
+    pub fn get_unit_card_index(&self) -> i32 {
+        self.unit_card_index
+    }
+
+}

--- a/src/game_field_unit/service/request/mod.rs
+++ b/src/game_field_unit/service/request/mod.rs
@@ -16,3 +16,4 @@ pub mod apply_catastrophic_damage_to_field_unit_request;
 pub mod detach_multiple_energy_from_field_unit_request;
 pub mod get_current_attached_energy_of_field_unit_by_index_request;
 pub mod judge_death_of_unit_request;
+pub mod check_turn_action_request;

--- a/src/game_field_unit/service/response/check_turn_action_response.rs
+++ b/src/game_field_unit/service/response/check_turn_action_response.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckTurnActionResponse {
+    turn_action: bool
+}
+
+impl CheckTurnActionResponse {
+    pub fn new(turn_action: bool) -> Self {
+        CheckTurnActionResponse { turn_action }
+    }
+
+    pub fn turn_action(&self) -> bool {
+        self.turn_action
+    }
+}

--- a/src/game_field_unit/service/response/mod.rs
+++ b/src/game_field_unit/service/response/mod.rs
@@ -16,3 +16,4 @@ pub mod apply_catastrophic_damage_to_field_unit_response;
 pub mod detach_multiple_energy_from_field_unit_response;
 pub mod get_current_attached_energy_of_field_unit_by_index_response;
 pub mod judge_death_of_unit_response;
+pub mod check_turn_action_response;


### PR DESCRIPTION
필드 유닛의 액션 후에 유닛이 해당 턴에 액션을 취했다는 정보를 저장합니다 [TCG-CGS-326], 턴 종료 시에 필드 유닛 전체의 액션 정보를 초기화합니다 [TCG-CGS-327]