### PR TITLE
fix:[황영찬] UI와 false message Enum 맞춤 [TCG-CGS-442]

### DIFF
--- a/src/common/message/false_message_enum.rs
+++ b/src/common/message/false_message_enum.rs
@@ -28,6 +28,10 @@ impl From<i32> for FalseMessage {
             4 => FalseMessage::SupportUsageOver,
             11 => FalseMessage::NotEnoughBasicAttackEnergy,
             12 => FalseMessage::MythicalCardRoundLimit,
+            13 => FalseMessage::NotYourTurnFieldEnergy,
+            14 => FalseMessage::UnattackableUnit,
+            15 => FalseMessage::UnitFrozen,
+
             _ => panic!("Invalid enum value"),
         }
     }

--- a/src/common/message/false_message_enum.rs
+++ b/src/common/message/false_message_enum.rs
@@ -7,12 +7,14 @@ pub enum FalseMessage {
     UnitActionLimitOver = 2,
     NotYourTurn = 3,
     SupportUsageOver = 4,
-    UnitFrozen = 5,
-    UnattackableUnit = 6,
 
     NotEnoughBasicAttackEnergy = 11,
     MythicalCardRoundLimit = 12,
     NotYourTurnFieldEnergy = 13,
+    UnattackableUnit = 14,
+    UnitFrozen = 15,
+
+
 }
 
 impl From<i32> for FalseMessage {


### PR DESCRIPTION
13 상대 턴에 필드에너지를 사용할 수 없다
14 망령 기본공격 면역을 공격할 수 없다
15 빙결상태라 공격할 수 없다